### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,11 @@ name = "fdasrsf"
 version = "2.3.7"
 description = "functional data analysis using the square root slope framework"
 authors = [
-    "J. Derek Tucker <jdtuck@sandia.gov>"
+	{name = "J. Derek Tucker", email = "jdtuck@sandia.gov"}
 ]
-license = "BSD"
+license = {text = "BSD 3-Clause"}
 readme = "README.md"
-python = "^3.6"
-homepage = "http://research.tetonedge.net"
-repository = "https://github.com/jdtuck/fdasrsf_python"
-documentation = "https://fdasrsf-python.readthedocs.io/en/latest/"
+requires-python = ">=3.6"
 
 keywords = ["functional data analysis"]
 
@@ -38,6 +35,11 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.6',
 ]
+
+[project.urls]
+homepage = "http://research.tetonedge.net"
+repository = "https://github.com/jdtuck/fdasrsf_python"
+documentation = "https://fdasrsf-python.readthedocs.io/en/latest/"
 
 [build-system]
 requires = ["setuptools>=46.0", "wheel", "cffi>=1.0.0", "Cython", "numpy"]  # PEP 518 - what is required to build


### PR DESCRIPTION
The recent version of setuptools checks strict adherence to PEP 621, refusing to install a package with an invalid pyproject.toml file.
As the pyproject.toml file in this repository was different from the PEP 621, this project could not be installed with recent versions of setuptools.
I have fixed this file and validated it with `validate-pyproject`, which is the tool that the new version of setuptool uses.

Fixes #23.