### PR TITLE
Update cibuildwheel

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This updates cibuildwheel to the newest version, which includes support for python 3.13 (and 3.14 when other packages like numba are ready).

The existing version of cibuildwheel (2.16.5) didn't have the ability to build 3.13, even though it was specified at the top of the github action.

This should resolve https://github.com/jdtuck/fdasrsf_python/issues/72

I checked and it seems to build no problem for 3.13!